### PR TITLE
feat: add `prefix` query method for key-prefix scans

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -88,6 +88,27 @@ kafka:
   keyField: productId
 ```
 
+#### query
+
+Default: Object (required)
+
+Defines how data is retrieved from the state store. `query.method` is one of:
+
+| Method | Returns | Required fields |
+|--|--|--|
+| `all` | every entry in the store | — |
+| `get` | a single entry by key | `key` |
+| `prefix` | every entry whose key starts with a prefix, ordered by key | `prefix` |
+
+`key` and `prefix` are templates that may embed path parameters with `${parameters.<name>}`,
+for example `message:${parameters.conversationId}:`. Quote the value in YAML if it contains a `:`
+(e.g. `prefix: "message:${parameters.conversationId}:"`), since `:` is a YAML mapping indicator.
+
+`prefix` requires `serializer.key: string`. Prefix scans depend on the lexicographic ordering of the
+serialized key bytes, and Avro's binary encoding is not prefix-preserving, so Avro keys are rejected
+for `prefix`. Pad numeric key components to a fixed width (e.g. `0000000010`) so they sort numerically
+rather than lexicographically.
+
 #### mergeKey
 
 Default: false

--- a/README.md
+++ b/README.md
@@ -101,6 +101,71 @@ paths:
 
 
 
+## Get items by key prefix
+
+The `prefix` query method returns every entry whose key starts with a given prefix, ordered by the
+key. It is ideal for listing a logical group without storing the group membership in a single record
+— for example, every message in a conversation (`message:<conversationId>:<offset>`), or every
+conversation in the system (`conversation:`).
+
+> **Keys must be `string`.** Prefix scans rely on the lexicographic ordering of the serialized key
+> bytes. Avro keys are rejected for `prefix` because Avro's binary encoding (length-prefixed strings,
+> zig-zag varint numbers) is not prefix-preserving. Pad numeric components to a fixed width
+> (e.g. `0000000010`) so they sort numerically.
+
+**Config**
+
+```yaml
+kafka:
+  application.id: kafka-streams-101
+  bootstrap.servers: localhost:9092
+
+paths:
+  /conversations/{conversationId}/messages:
+    parameters:
+    - name: conversationId
+      in: path
+      description: the conversation identifier
+    get:
+      kafka:
+        topic: conversation-messages
+        query:
+          method: prefix
+          # Quote the value because it contains ':' (a YAML mapping indicator)
+          prefix: "message:${parameters.conversationId}:"
+        serializer:
+          key: string
+          value: string
+      responses:
+        '200':
+          description: All messages for a conversation
+          content:
+            application/json:
+              schema:
+                type: array
+```
+
+**Produce**
+
+```sh
+message:conv1:0000000001;{ "text": "hello" }
+message:conv1:0000000002;{ "text": "how are you?" }
+message:conv2:0000000001;{ "text": "different conversation" }
+```
+
+**Query**
+
+```sh
+curl "localhost:7001/conversations/conv1/messages" | jq
+
+[
+  { "text": "hello" },
+  { "text": "how are you?" }
+]
+```
+
+A prefix with no matches returns `[]`.
+
 # Performance Benchmarks
 
 We ran some load tests to see how the system performs with real-world data volumes and access patterns.
@@ -134,6 +199,7 @@ Also, the results will vary based on hardware, query method, and disk type.
 |--|--|
 | List all items | ✅
 | Get single item | ✅
+| Get items by key prefix | ✅
 
 
 **Data Type (Key)**

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ curl "localhost:7001/conversations/conv1/messages" | jq
 
 A prefix with no matches returns `[]`.
 
+For a complete, runnable walkthrough — listing conversations, fetching one, and replaying its
+messages from a single topic — see [`examples/conversation-store`](examples/conversation-store).
+
 # Performance Benchmarks
 
 We ran some load tests to see how the system performs with real-world data volumes and access patterns.

--- a/examples/conversation-store/README.md
+++ b/examples/conversation-store/README.md
@@ -1,0 +1,81 @@
+# Conversation store example
+
+Serves chat-style conversations and their messages straight from a single Kafka topic, using the
+`prefix` and `get` query methods. No database, no per-conversation index record.
+
+| Lookup | Endpoint | Query method |
+|--|--|--|
+| List all conversations | `GET /conversations` | `prefix` on `conversation:` |
+| One conversation's metadata | `GET /conversations/{id}` | `get` on `conversation:{id}` |
+| A conversation's messages (ordered) | `GET /conversations/{id}/messages` | `prefix` on `message:{id}:` |
+
+## Key design
+
+A single topic `conversation-store` (string keys, JSON string values) holds two record types,
+separated by key prefix so a `conversation:` scan never returns messages:
+
+```
+conversation:conv1            {"name":"Trip planning","state":"open"}
+message:conv1:0000000001      {"role":"user","text":"hello"}
+message:conv1:0000000002      {"role":"assistant","text":"how are you?"}
+```
+
+Offsets are **zero-padded** so they sort numerically (RocksDB orders keys by serialized bytes;
+unpadded, `10` would sort before `2`). Keys must be `string` — Avro's binary encoding is not
+prefix-preserving.
+
+## Run it
+
+1. Start Kafka and create the topic:
+
+   ```sh
+   docker compose up -d kafka
+   docker exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 \
+     --create --topic conversation-store --partitions 6 --replication-factor 1
+   ```
+
+2. Produce a couple of conversations and some messages:
+
+   ```sh
+   printf '%s\n' \
+     'conversation:conv1;{"name":"Trip planning","state":"open"}' \
+     'conversation:conv2;{"name":"Bug triage","state":"closed"}' \
+     'message:conv1:0000000001;{"role":"user","text":"hello"}' \
+     'message:conv1:0000000002;{"role":"assistant","text":"how are you?"}' \
+     'message:conv1:0000000010;{"role":"user","text":"much later"}' \
+     'message:conv2:0000000001;{"role":"user","text":"different conversation"}' \
+   | docker exec -i kafka /opt/kafka/bin/kafka-console-producer.sh \
+       --bootstrap-server localhost:9092 --topic conversation-store \
+       --property "parse.key=true" --property "key.separator=;"
+   ```
+
+3. Build and run the service against this config:
+
+   ```sh
+   ./gradlew shadowJar
+   java -jar build/libs/kafka-as-a-microservice-standalone-*.jar examples/conversation-store/config.yaml
+   ```
+
+## Query it
+
+```sh
+# 1. List all conversations (messages are excluded — prefix isolation)
+curl -s localhost:7001/conversations | jq
+# [ {"name":"Trip planning","state":"open"}, {"name":"Bug triage","state":"closed"} ]
+
+# 2. One conversation's metadata
+curl -s localhost:7001/conversations/conv1 | jq
+# {"name":"Trip planning","state":"open"}
+
+# 3. A conversation's messages, in order (padding keeps offset 2 before offset 10)
+curl -s localhost:7001/conversations/conv1/messages | jq
+# [ {"role":"user","text":"hello"},
+#   {"role":"assistant","text":"how are you?"},
+#   {"role":"user","text":"much later"} ]
+```
+
+New messages produced to the topic appear in the results within a second or two — the GlobalKTable
+updates live.
+
+> **Tip:** set `includeKey: true` under `kafka:` on any endpoint to have each object carry its own
+> key under a `"key"` field (e.g. `"key":"message:conv1:0000000001"`).

--- a/examples/conversation-store/config.yaml
+++ b/examples/conversation-store/config.yaml
@@ -1,0 +1,91 @@
+---
+# Conversation store example.
+#
+# A single compacted topic holds two kinds of records, distinguished by key prefix:
+#   conversation:<id>            -> conversation metadata  {"name": ..., "state": ...}
+#   message:<id>:<paddedOffset>  -> a message in that conversation  {"role": ..., "text": ...}
+#
+# This demonstrates the three lookups the `prefix` (and `get`) query methods enable, without ever
+# storing a list of ids in a single record:
+#   1. GET /conversations                       -> list all conversations   (prefix "conversation:")
+#   2. GET /conversations/{id}                   -> one conversation's metadata (get)
+#   3. GET /conversations/{id}/messages          -> that conversation's messages (prefix "message:<id>:")
+#
+# Offsets are zero-padded to a fixed width so they sort numerically (RocksDB orders keys by their
+# serialized bytes; without padding "10" would sort before "2"). Keys must be `string` for prefix
+# scans — Avro's binary encoding is not prefix-preserving.
+
+kafka:
+  application.id: conversation-store-example
+  bootstrap.servers: localhost:9092
+  # Required to construct the client even when keys/values are strings (no schema lookups occur).
+  schema.registry.url: http://localhost:8081
+
+paths:
+  # 1. List all conversations
+  /conversations:
+    get:
+      description: List all conversations
+      kafka:
+        topic: conversation-store
+        query:
+          method: prefix
+          prefix: "conversation:"
+        serializer:
+          key: string
+          value: string
+      responses:
+        '200':
+          description: All conversations
+          content:
+            application/json:
+              schema:
+                type: array
+
+  # 2. One conversation's metadata
+  /conversations/{conversationId}:
+    parameters:
+    - name: conversationId
+      in: path
+      description: the conversation identifier
+    get:
+      description: Get one conversation's metadata
+      kafka:
+        topic: conversation-store
+        query:
+          method: get
+          key: "conversation:${parameters.conversationId}"
+        serializer:
+          key: string
+          value: string
+      responses:
+        '200':
+          description: A single conversation
+          content:
+            application/json:
+              schema:
+                type: object
+
+  # 3. A conversation's messages, in order
+  /conversations/{conversationId}/messages:
+    parameters:
+    - name: conversationId
+      in: path
+      description: the conversation identifier
+    get:
+      description: List all messages in a conversation
+      kafka:
+        topic: conversation-store
+        query:
+          method: prefix
+          prefix: "message:${parameters.conversationId}:"
+        serializer:
+          key: string
+          value: string
+      responses:
+        '200':
+          description: All messages for a conversation
+          content:
+            application/json:
+              schema:
+                type: array

--- a/src/main/java/io/confluent/developer/Configuration.java
+++ b/src/main/java/io/confluent/developer/Configuration.java
@@ -80,11 +80,14 @@ public class Configuration {
     public static class QueryConfig {
         private String method;
         private String key;
+        private String prefix;
 
         public String getMethod() { return method; }
         public void setMethod(String method) { this.method = method; }
         public String getKey() { return key; }
         public void setKey(String key) { this.key = key; }
+        public String getPrefix() { return prefix; }
+        public void setPrefix(String prefix) { this.prefix = prefix; }
     }
 
     public static class SerializerConfig {
@@ -217,25 +220,45 @@ public class Configuration {
         if ("all".equalsIgnoreCase(queryMethod)) {
             return;
         }
-    
+
+        // The 'prefix' method scans all keys sharing a common prefix and needs a `prefix` template
+        if ("prefix".equalsIgnoreCase(queryMethod)) {
+            String prefix = queryConfig.getPrefix();
+            if (prefix == null || prefix.isEmpty()) {
+                throw new IllegalArgumentException("`kafka.query.prefix` is required when `kafka.query.method` is 'prefix' for path: " + pathConfig.getPath());
+            }
+            validateParameterReferences(pathConfig, prefix, "kafka.query.prefix");
+            return;
+        }
+
         String queryKey = queryConfig.getKey();
 
         if (queryKey == null) {
             throw new IllegalArgumentException("Query key is missing in Kafka config for path: " + queryConfig);
         }
-        
-        if (queryKey.contains("${parameters.")) {
-            String paramName = queryKey.substring(queryKey.indexOf("${parameters.") + 13, queryKey.indexOf("}"));
-            boolean found = false;
 
-            for (ParameterConfig param : pathConfig.getParameters()) {
-                if (param.getName().equals(paramName)) {
-                    found = true;
-                    break;
+        validateParameterReferences(pathConfig, queryKey, "kafka.query.key");
+    }
+
+    private static final java.util.regex.Pattern PARAM_PATTERN =
+            java.util.regex.Pattern.compile("\\$\\{parameters\\.([^}]+)\\}");
+
+    // Verifies that every ${parameters.X} placeholder in a key template refers to a declared path parameter
+    private void validateParameterReferences(PathConfig pathConfig, String template, String fieldLabel) {
+        java.util.regex.Matcher matcher = PARAM_PATTERN.matcher(template);
+        while (matcher.find()) {
+            String paramName = matcher.group(1);
+            boolean found = false;
+            if (pathConfig.getParameters() != null) {
+                for (ParameterConfig param : pathConfig.getParameters()) {
+                    if (param.getName().equals(paramName)) {
+                        found = true;
+                        break;
+                    }
                 }
             }
             if (!found) {
-                throw new IllegalArgumentException("Parameter " + paramName + " used in `kafka.query.key` is not defined in path parameters for path: " + pathConfig.getPath());
+                throw new IllegalArgumentException("Parameter " + paramName + " used in `" + fieldLabel + "` is not defined in path parameters for path: " + pathConfig.getPath());
             }
         }
     }
@@ -283,10 +306,10 @@ public class Configuration {
     
         // Check kafka.query.method
         String queryMethod = query.getMethod();
-        if (queryMethod == null || (!queryMethod.equals("get") && !queryMethod.equals("all"))) {
-            throw new IllegalArgumentException("`kafka.query.method` must be either 'get' or 'all' for path: " + path);
+        if (queryMethod == null || (!queryMethod.equals("get") && !queryMethod.equals("all") && !queryMethod.equals("prefix"))) {
+            throw new IllegalArgumentException("`kafka.query.method` must be one of 'get', 'all', or 'prefix' for path: " + path);
         }
-    
+
         // Check kafka.serializer
         SerializerConfig serializer = kafka.getSerializer();
         // Check kafka.serializer.key
@@ -294,7 +317,14 @@ public class Configuration {
         if (keySerializer == null || (!keySerializer.equals("string") && !keySerializer.equals("avro"))) {
             throw new IllegalArgumentException("`kafka.serializer.key` must be set and is one of 'string' or 'avro' for path: " + path);
         }
-        
+
+        // Prefix scans rely on lexicographic ordering of the serialized key bytes. Avro's binary encoding
+        // (length-prefixed strings, zig-zag varint numbers) is not prefix-preserving, so prefix is string-only.
+        if ("prefix".equals(queryMethod) && !"string".equals(keySerializer)) {
+            throw new IllegalArgumentException(
+                "`kafka.serializer.key` must be 'string' when `kafka.query.method` is 'prefix' for path: " + path);
+        }
+
         // If key serializer is avro, keyField must be set
         if ("avro".equalsIgnoreCase(keySerializer)) {
             String keyField = kafka.getKeyField();
@@ -384,6 +414,7 @@ public class Configuration {
         if (queryData != null) {
             queryConfig.setMethod((String) queryData.get("method"));
             queryConfig.setKey((String) queryData.get("key"));
+            queryConfig.setPrefix((String) queryData.get("prefix"));
         }
         return queryConfig;
     }

--- a/src/main/java/io/confluent/developer/RestApiServer.java
+++ b/src/main/java/io/confluent/developer/RestApiServer.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
@@ -180,6 +181,10 @@ public class RestApiServer {
                         String key = resolveQueryKey(methodConfig.getKafka().getQuery().getKey(), pathParams);
                         response = getValue(key, methodConfig);
                         statusCode = (response != null) ? 200 : 404;
+                    } else if ("prefix".equals(queryMethod)) {
+                        String prefix = resolveQueryKey(methodConfig.getKafka().getQuery().getPrefix(), pathParams);
+                        response = getPrefixValues(prefix, methodConfig);
+                        statusCode = 200;
                     } else {
                         response = "Unsupported query method";
                         statusCode = 400;
@@ -265,6 +270,46 @@ public class RestApiServer {
             
             String result = objectMapper.writeValueAsString(jsonArray);
             return result;
+        }
+
+        private String getPrefixValues(String prefix, Configuration.MethodConfig methodConfig) throws IOException {
+            String storeName = methodConfig.getKafka().getTopic() + "-store";
+
+            ReadOnlyKeyValueStore<Object, Object> keyValueStore =
+                    streams.store(StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
+
+            logger.debug("Prefix scan on store '{}' with prefix '{}'", storeName, prefix);
+
+            ArrayNode jsonArray = objectMapper.createArrayNode();
+
+            // prefixScan returns every entry whose key starts with the prefix, ordered by the serialized key bytes.
+            try (var iterator = keyValueStore.prefixScan(prefix, new StringSerializer())) {
+
+                while (iterator.hasNext()) {
+                    try {
+                        var entry = iterator.next();
+
+                        try {
+                            JsonNode item = processValue(entry, methodConfig);
+                            jsonArray.add(item);
+                        } catch (IOException e) {
+                            logger.warn("Skipping entry IOException - {}", e.getMessage());
+                        }
+
+                    } catch (org.apache.kafka.common.errors.SerializationException e) {
+                        // Schema deserialization failed - this record is corrupted/incompatible
+                        logger.warn("Skipping record due to deserialization error: {}", e.getMessage());
+                        break;
+                    } catch (Exception e) {
+                        // Unexpected error - log and try to continue
+                        logger.error("Unexpected error during prefix iteration: {}", e.getMessage(), e);
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Fatal exception during prefix iteration: {}", e.getMessage(), e);
+            }
+
+            return objectMapper.writeValueAsString(jsonArray);
         }
 
         private JsonNode processValue(KeyValue<Object, Object> entry, MethodConfig methodConfig) throws IOException {

--- a/src/main/java/io/confluent/developer/metrics/RestApiMetrics.java
+++ b/src/main/java/io/confluent/developer/metrics/RestApiMetrics.java
@@ -26,6 +26,11 @@ public class RestApiMetrics implements DynamicMBean {
         try {
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             ObjectName name = new ObjectName("io.confluent.developer:type=RestApiMetrics");
+            // Registration is idempotent: a prior server instance in this JVM (e.g. after a
+            // Kafka Streams restart) may have left the MBean registered. Replace it.
+            if (mbs.isRegistered(name)) {
+                mbs.unregisterMBean(name);
+            }
             mbs.registerMBean(this, name);
             logger.info("RestApiMetrics MBean registered successfully");
         } catch (Exception e) {

--- a/src/test/java/io/confluent/developer/ConfigurationTest.java
+++ b/src/test/java/io/confluent/developer/ConfigurationTest.java
@@ -366,7 +366,7 @@ public class ConfigurationTest {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             Configuration.fromFile(configPath.toString());
         });
-        assertTrue(exception.getMessage().contains("`kafka.query.method` must be either 'get' or 'all' for path: /flights/{flightId}"));
+        assertTrue(exception.getMessage().contains("`kafka.query.method` must be one of 'get', 'all', or 'prefix' for path: /flights/{flightId}"));
     }
 
     @Test
@@ -711,5 +711,155 @@ public class ConfigurationTest {
         });
 
         assertTrue(exception.getMessage().contains("Only object or array schema types are supported. Found: string for path: /flights"));
+    }
+
+    @Test
+    public void testValidPrefixConfiguration(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("valid-prefix-config.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations/{conversationId}/messages:\n" +
+            "    parameters:\n" +
+            "    - name: conversationId\n" +
+            "      in: path\n" +
+            "      description: the conversation identifier\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: conversation-messages\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "          prefix: \"message:${parameters.conversationId}:\"\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All messages for a conversation\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+
+        Configuration config = Configuration.fromFile(configPath.toString());
+        assertNotNull(config);
+        Configuration.MethodConfig method =
+            config.getPaths().get("/conversations/{conversationId}/messages").getMethods().get("get");
+        assertEquals("prefix", method.getKafka().getQuery().getMethod());
+        assertEquals("message:${parameters.conversationId}:", method.getKafka().getQuery().getPrefix());
+    }
+
+    @Test
+    public void testPrefixMissingPrefix(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("prefix-missing.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations:\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: conversation-messages\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All conversations\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Configuration.fromFile(configPath.toString());
+        });
+        assertTrue(exception.getMessage().contains("`kafka.query.prefix` is required when `kafka.query.method` is 'prefix' for path: /conversations"));
+    }
+
+    @Test
+    public void testPrefixUndefinedParameterReference(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("prefix-bad-param.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations/{conversationId}/messages:\n" +
+            "    parameters:\n" +
+            "    - name: conversationId\n" +
+            "      in: path\n" +
+            "      description: the conversation identifier\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: conversation-messages\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "          prefix: \"message:${parameters.missing}:\"\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All messages for a conversation\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Configuration.fromFile(configPath.toString());
+        });
+        assertTrue(exception.getMessage().contains("Parameter missing used in `kafka.query.prefix` is not defined in path parameters for path: /conversations/{conversationId}/messages"));
+    }
+
+    @Test
+    public void testPrefixRejectsAvroKey(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("prefix-avro-key.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations/{conversationId}/messages:\n" +
+            "    parameters:\n" +
+            "    - name: conversationId\n" +
+            "      in: path\n" +
+            "      description: the conversation identifier\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: conversation-messages\n" +
+            "        keyField: id\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "          prefix: ${parameters.conversationId}\n" +
+            "        serializer:\n" +
+            "          key: avro\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All messages for a conversation\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Configuration.fromFile(configPath.toString());
+        });
+        assertTrue(exception.getMessage().contains("`kafka.serializer.key` must be 'string' when `kafka.query.method` is 'prefix' for path: /conversations/{conversationId}/messages"));
     }
 }

--- a/src/test/java/io/confluent/developer/PrefixIntegrationTest.java
+++ b/src/test/java/io/confluent/developer/PrefixIntegrationTest.java
@@ -1,0 +1,185 @@
+package io.confluent.developer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end integration test for the `prefix` query method.
+ *
+ * Builds the REAL topology from a YAML config via {@link KafkaStreamsApplication#buildTopology},
+ * drives records through a {@link TopologyTestDriver} (real String serdes + a real materialized
+ * GlobalKTable state store), and serves that live store over HTTP through {@link RestApiServer}.
+ * Validates the full stack: config &rarr; topology &rarr; state store &rarr; prefix scan &rarr; HTTP/JSON.
+ */
+public class PrefixIntegrationTest {
+
+    private static final int PORT = 17657;
+    private static final String TOPIC = "conversation-messages";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private TopologyTestDriver testDriver;
+    private RestApiServer server;
+
+    @BeforeEach
+    public void resetStaticStoreRegistry() throws Exception {
+        // buildTopology dedupes stores via a static Set that persists across calls; clear it so each
+        // test builds its topology from scratch.
+        Field f = KafkaStreamsApplication.class.getDeclaredField("createdStores");
+        f.setAccessible(true);
+        ((Set<?>) f.get(null)).clear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+        if (testDriver != null) {
+            testDriver.close();
+            testDriver = null;
+        }
+    }
+
+    private Configuration writeConfig(Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("prefix-it-config.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: prefix-integration-test\n" +
+            "  bootstrap.servers: dummy:1234\n" +
+            "  schema.registry.url: http://localhost:8081\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations/{conversationId}/messages:\n" +
+            "    parameters:\n" +
+            "    - name: conversationId\n" +
+            "      in: path\n" +
+            "      description: the conversation identifier\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: " + TOPIC + "\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "          prefix: \"message:${parameters.conversationId}:\"\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All messages for a conversation\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+        return Configuration.fromFile(configPath.toString());
+    }
+
+    private void bootstrap(Path tempDir) throws Exception {
+        Configuration config = writeConfig(tempDir);
+
+        Topology topology = KafkaStreamsApplication.buildTopology(config);
+
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "prefix-integration-test");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.STATE_DIR_CONFIG, tempDir.resolve("state").toString());
+
+        testDriver = new TopologyTestDriver(topology, props);
+
+        TestInputTopic<String, String> input =
+            testDriver.createInputTopic(TOPIC, new StringSerializer(), new StringSerializer());
+
+        // Two interleaved conversations; padded offsets keep ordering numeric.
+        input.pipeInput("message:conv1:0000000001", "{\"text\":\"hello\"}");
+        input.pipeInput("message:conv1:0000000002", "{\"text\":\"how are you?\"}");
+        input.pipeInput("message:conv1:0000000010", "{\"text\":\"much later\"}");
+        input.pipeInput("message:conv2:0000000001", "{\"text\":\"different conversation\"}");
+
+        ReadOnlyKeyValueStore<Object, Object> store = testDriver.getKeyValueStore(TOPIC + "-store");
+        assertNotNull(store, "Expected the topology to materialize a queryable store named " + TOPIC + "-store");
+
+        KafkaStreams streams = Mockito.mock(KafkaStreams.class);
+        Mockito.doReturn(store).when(streams).store(Mockito.any());
+
+        server = new RestApiServer(streams, config, PORT);
+        server.start();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:" + PORT + path))
+            .GET()
+            .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testPrefixScopesToConversationOverRealStore(@TempDir Path tempDir) throws Exception {
+        bootstrap(tempDir);
+
+        HttpResponse<String> response = get("/conversations/conv1/messages");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertTrue(body.isArray());
+        // All three conv1 messages, ordered (offset 2 before 10 thanks to padding); conv2 excluded.
+        assertEquals(3, body.size());
+        assertEquals("hello", body.get(0).get("text").asText());
+        assertEquals("how are you?", body.get(1).get("text").asText());
+        assertEquals("much later", body.get(2).get("text").asText());
+    }
+
+    @Test
+    public void testPrefixOtherConversationOverRealStore(@TempDir Path tempDir) throws Exception {
+        bootstrap(tempDir);
+
+        HttpResponse<String> response = get("/conversations/conv2/messages");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals(1, body.size());
+        assertEquals("different conversation", body.get(0).get("text").asText());
+    }
+
+    @Test
+    public void testPrefixNoMatchOverRealStore(@TempDir Path tempDir) throws Exception {
+        bootstrap(tempDir);
+
+        HttpResponse<String> response = get("/conversations/conv9/messages");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertTrue(body.isArray());
+        assertEquals(0, body.size());
+    }
+}

--- a/src/test/java/io/confluent/developer/RestApiServerPrefixTest.java
+++ b/src/test/java/io/confluent/developer/RestApiServerPrefixTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Exercises the `prefix` query method end-to-end: an HTTP request hits the running
  * {@link RestApiServer}, which performs a prefix scan against a mocked Kafka Streams store backed by
- * a TreeMap (whose String key ordering mirrors the real RocksDB store's lexicographic byte ordering).
+ * a TreeMap (whose natural ordering matches the UTF-8 byte ordering for the ASCII keys used here).
  */
 public class RestApiServerPrefixTest {
 

--- a/src/test/java/io/confluent/developer/RestApiServerPrefixTest.java
+++ b/src/test/java/io/confluent/developer/RestApiServerPrefixTest.java
@@ -1,0 +1,225 @@
+package io.confluent.developer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the `prefix` query method end-to-end: an HTTP request hits the running
+ * {@link RestApiServer}, which performs a prefix scan against a mocked Kafka Streams store backed by
+ * a TreeMap (whose String key ordering mirrors the real RocksDB store's lexicographic byte ordering).
+ */
+public class RestApiServerPrefixTest {
+
+    private static final int PORT = 17656;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private RestApiServer server;
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+
+    private Configuration prefixConfig(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("prefix-config.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "  schema.registry.url: http://localhost:8081\n" +
+            "\n" +
+            "paths:\n" +
+            "  /conversations/{conversationId}/messages:\n" +
+            "    parameters:\n" +
+            "    - name: conversationId\n" +
+            "      in: path\n" +
+            "      description: the conversation identifier\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: conversation-messages\n" +
+            "        query:\n" +
+            "          method: prefix\n" +
+            "          prefix: \"message:${parameters.conversationId}:\"\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: All messages for a conversation\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+        return Configuration.fromFile(configPath.toString());
+    }
+
+    private void startServer(Configuration config, ReadOnlyKeyValueStore<Object, Object> store) throws Exception {
+        KafkaStreams streams = Mockito.mock(KafkaStreams.class);
+        Mockito.doReturn(store).when(streams).store(Mockito.any());
+        server = new RestApiServer(streams, config, PORT);
+        server.start();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:" + PORT + path))
+            .GET()
+            .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testPrefixReturnsOnlyMatchingConversationInOrder(@TempDir Path tempDir) throws Exception {
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        store.put("message:conv1:0000000001", "{\"text\":\"a\"}");
+        store.put("message:conv1:0000000002", "{\"text\":\"b\"}");
+        store.put("message:conv1:0000000010", "{\"text\":\"j\"}");
+        store.put("message:conv2:0000000001", "{\"text\":\"other\"}");
+
+        startServer(prefixConfig(tempDir), store);
+
+        HttpResponse<String> response = get("/conversations/conv1/messages");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertTrue(body.isArray());
+        // Only conv1, ordered; padding keeps offset 2 before offset 10; conv2 excluded.
+        assertEquals(3, body.size());
+        assertEquals("a", body.get(0).get("text").asText());
+        assertEquals("b", body.get(1).get("text").asText());
+        assertEquals("j", body.get(2).get("text").asText());
+    }
+
+    @Test
+    public void testPrefixWithNoMatchesReturnsEmptyArray(@TempDir Path tempDir) throws Exception {
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        store.put("message:conv2:0000000001", "{\"text\":\"other\"}");
+
+        startServer(prefixConfig(tempDir), store);
+
+        HttpResponse<String> response = get("/conversations/conv1/messages");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertTrue(body.isArray());
+        assertEquals(0, body.size());
+    }
+
+    /**
+     * In-memory {@link ReadOnlyKeyValueStore} backed by a TreeMap. prefixScan is implemented to mirror
+     * the real store: every entry whose key starts with the prefix, in sorted (byte-lexicographic) order.
+     */
+    static class FakeKeyValueStore implements ReadOnlyKeyValueStore<Object, Object> {
+        private final TreeMap<String, String> data = new TreeMap<>();
+
+        void put(String key, String value) {
+            data.put(key, value);
+        }
+
+        @Override
+        public Object get(Object key) {
+            return data.get(key);
+        }
+
+        @Override
+        public <PS extends Serializer<P>, P> KeyValueIterator<Object, Object> prefixScan(P prefix, PS prefixKeySerializer) {
+            String p = (String) prefix;
+            List<KeyValue<Object, Object>> entries = new ArrayList<>();
+            for (var e : data.tailMap(p, true).entrySet()) {
+                if (!e.getKey().startsWith(p)) {
+                    break; // sorted: once we pass the prefix, no further matches
+                }
+                entries.add(new KeyValue<>(e.getKey(), e.getValue()));
+            }
+            return new ListIterator(entries);
+        }
+
+        @Override
+        public KeyValueIterator<Object, Object> range(Object from, Object to) {
+            List<KeyValue<Object, Object>> entries = new ArrayList<>();
+            for (var e : data.subMap((String) from, true, (String) to, true).entrySet()) {
+                entries.add(new KeyValue<>(e.getKey(), e.getValue()));
+            }
+            return new ListIterator(entries);
+        }
+
+        @Override
+        public KeyValueIterator<Object, Object> all() {
+            List<KeyValue<Object, Object>> entries = new ArrayList<>();
+            for (var e : data.entrySet()) {
+                entries.add(new KeyValue<>(e.getKey(), e.getValue()));
+            }
+            return new ListIterator(entries);
+        }
+
+        @Override
+        public long approximateNumEntries() {
+            return data.size();
+        }
+    }
+
+    static class ListIterator implements KeyValueIterator<Object, Object> {
+        private final Iterator<KeyValue<Object, Object>> it;
+        private final List<KeyValue<Object, Object>> entries;
+        private int index = 0;
+
+        ListIterator(List<KeyValue<Object, Object>> entries) {
+            this.entries = entries;
+            this.it = entries.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return it.hasNext();
+        }
+
+        @Override
+        public KeyValue<Object, Object> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            index++;
+            return it.next();
+        }
+
+        @Override
+        public Object peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return entries.get(index).key;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a query method, **`prefix`**, alongside `all` and `get`. It returns every entry whose key starts with a given prefix, ordered by the serialized key bytes — ideal for listing a logical group without storing membership in a single record (e.g. every message in a conversation, or every conversation in the system).

```yaml
query:
  method: prefix
  prefix: "message:${parameters.conversationId}:"   # quote: ':' is a YAML mapping indicator
serializer:
  key: string     # required for prefix
  value: string
```

```sh
curl "localhost:7001/conversations/conv1/messages" | jq
# [ {"text":"hello"}, {"text":"how are you?"} ]
```

## Changes

- **Configuration** — parse `query.prefix`; accept `prefix` as a method; **enforce `string` keys for `prefix`** (Avro's binary encoding — length-prefixed strings, zig-zag varint numbers — is not prefix-preserving); validate every `${parameters.x}` reference across `key`/`prefix`.
- **RestApiServer** — `prefix` branch + `getPrefixValues()` backed by `store.prefixScan(prefix, new StringSerializer())`, mirroring the existing `all` iteration/serialization.
- **RestApiMetrics** — make JMX MBean registration idempotent. Previously a second `RestApiServer` in one JVM (e.g. after a Kafka Streams restart) threw `InstanceAlreadyExistsException`.
- **Docs** — README worked example + CONFIGURATION query-method table, both noting the string-key/padding requirement and YAML quoting for `:` in prefix values.

## Why string keys only

Prefix scans depend on lexicographic ordering of serialized key bytes. Pad numeric components to fixed width (`0000000010`) so they sort numerically. Avro keys are rejected at config-load time.

## Testing

`./gradlew clean test` → **33 tests, 33 succeeded**.

- `ConfigurationTest` (+4): valid prefix parsing, missing `prefix`, bad parameter reference, Avro-key rejection.
- `RestApiServerPrefixTest`: HTTP path over an in-memory store — prefix scoping/ordering and empty results.
- `PrefixIntegrationTest`: full stack — builds the real topology via `KafkaStreamsApplication.buildTopology`, drives records through `TopologyTestDriver` into a real RocksDB-backed GlobalKTable store, serves over HTTP, and asserts conversation scoping, padded ordering, and no-match windows.

## Note

This is a GlobalKTable-based library, so the prefix scan is complete and ordered on any node — at the cost of every node holding the full store. Independent of (and complementary to) the `range` method in #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)