### PR TITLE
feat: add `includeKey` option to include the lookup key in responses

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -159,6 +159,35 @@ whereas if false, then it returns:
 }
 ```
 
+#### includeKey
+
+Default: false
+
+If set to true, the lookup key is added to each returned object under a `key` field. This applies to
+every query method (`all`, `get`, and any range/prefix scans). For example, the entry:
+
+```
+key:   message:conv1:0000000011
+value: {"role": "assistant", "text": "a brand new reply"}
+```
+
+is returned as:
+
+```json
+{
+    "role": "assistant",
+    "text": "a brand new reply",
+    "key": "message:conv1:0000000011"
+}
+```
+
+String keys are emitted as-is; structured (Avro) keys are serialized to their JSON form. If the value
+is not a JSON object (e.g. an array or scalar) the key cannot be attached and the value is returned
+unchanged.
+
+This differs from [`mergeKey`](#mergekey): `mergeKey` merges the fields of an Avro **key object** into
+the value, whereas `includeKey` adds the raw key itself under `key` and works for plain string keys.
+
 ### responses
 
 response object that conforms to the OpenAPI. This object does not have an effect on the functionality of this API.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -181,9 +181,7 @@ is returned as:
 }
 ```
 
-String keys are emitted as-is; structured (Avro) keys are serialized to their JSON form. If the value
-is not a JSON object (e.g. an array or scalar) the key cannot be attached and the value is returned
-unchanged.
+String keys are emitted as-is; structured (Avro) keys are serialized to their JSON form. If the value is not a JSON object (e.g. an array or scalar) the key cannot be attached and the value is returned unchanged. If the value already contains a `key` field, `includeKey` is skipped to avoid overwriting payload data.
 
 This differs from [`mergeKey`](#mergekey): `mergeKey` merges the fields of an Avro **key object** into
 the value, whereas `includeKey` adds the raw key itself under `key` and works for plain string keys.

--- a/src/main/java/io/confluent/developer/Configuration.java
+++ b/src/main/java/io/confluent/developer/Configuration.java
@@ -61,6 +61,7 @@ public class Configuration {
         private SerializerConfig serializer;
         private boolean mergeKey = false;
         private boolean includeType = false;
+        private boolean includeKey = false;
         private String keyField;
 
         public String getTopic() { return topic; }
@@ -73,6 +74,8 @@ public class Configuration {
         public void setMergeKey(boolean mergeKey) { this.mergeKey = mergeKey; }
         public boolean isIncludeType() { return includeType; }
         public void setIncludeType(boolean includeType) { this.includeType = includeType; }
+        public boolean isIncludeKey() { return includeKey; }
+        public void setIncludeKey(boolean includeKey) { this.includeKey = includeKey; }
         public String getKeyField() { return keyField; }
         public void setKeyField(String keyField) { this.keyField = keyField; }
     }
@@ -369,6 +372,11 @@ public class Configuration {
         // Parse includeType if present (default: false)
         if (kafkaData.containsKey("includeType")) {
             kafkaConfig.setIncludeType((Boolean) kafkaData.get("includeType"));
+        }
+
+        // Parse includeKey if present (default: false) - adds the lookup key to the response under "key"
+        if (kafkaData.containsKey("includeKey")) {
+            kafkaConfig.setIncludeKey((Boolean) kafkaData.get("includeKey"));
         }
         
         // Parse keyField if present (required when key serializer is avro)

--- a/src/main/java/io/confluent/developer/RestApiServer.java
+++ b/src/main/java/io/confluent/developer/RestApiServer.java
@@ -421,6 +421,12 @@ public class RestApiServer {
                 return valueNode;
             }
 
+            // Don't clobber a "key" field that's already part of the payload.
+            if (valueNode.has("key")) {
+                logger.warn("includeKey skipped - value already has a 'key' field");
+                return valueNode;
+            }
+
             com.fasterxml.jackson.databind.node.ObjectNode result = (com.fasterxml.jackson.databind.node.ObjectNode) valueNode;
 
             // String keys are emitted as-is; structured (e.g. Avro) keys are serialized to their JSON form.

--- a/src/main/java/io/confluent/developer/RestApiServer.java
+++ b/src/main/java/io/confluent/developer/RestApiServer.java
@@ -269,18 +269,44 @@ public class RestApiServer {
 
         private JsonNode processValue(KeyValue<Object, Object> entry, MethodConfig methodConfig) throws IOException {
             boolean mergeKey = methodConfig.getKafka().isMergeKey();
+            boolean includeKey = methodConfig.getKafka().isIncludeKey();
             String valueSerializer = methodConfig.getKafka().getSerializer().getValue();
             JsonNode valueNode = serialize(entry.value, valueSerializer, methodConfig);
 
-            if (!mergeKey) {
+            JsonNode result = valueNode;
+
+            if (mergeKey) {
+                String keySerializer = methodConfig.getKafka().getSerializer().getKey();
+                JsonNode keyNode = serialize(entry.key, keySerializer, methodConfig);
+                result = mergeKeyIntoValue(keyNode, valueNode);
+            }
+
+            // includeKey adds the raw lookup key under a "key" field. Unlike mergeKey (which merges an
+            // Avro key object's fields), this works for plain string keys and is applied to every query method.
+            if (includeKey) {
+                result = addKeyField(entry.key, result, methodConfig);
+            }
+
+            return result;
+        }
+
+        private JsonNode addKeyField(Object key, JsonNode valueNode, MethodConfig methodConfig) throws IOException {
+            if (!valueNode.isObject()) {
+                logger.warn("includeKey skipped - value is not a JSON object");
                 return valueNode;
             }
 
-            String keySerializer = methodConfig.getKafka().getSerializer().getKey();
-            JsonNode keyNode = serialize(entry.key, keySerializer, methodConfig);
-            JsonNode mergedNode = mergeKeyIntoValue(keyNode, valueNode);
+            com.fasterxml.jackson.databind.node.ObjectNode result = (com.fasterxml.jackson.databind.node.ObjectNode) valueNode;
 
-            return mergedNode;
+            // String keys are emitted as-is; structured (e.g. Avro) keys are serialized to their JSON form.
+            if (key instanceof String) {
+                result.put("key", (String) key);
+            } else {
+                String keySerializer = methodConfig.getKafka().getSerializer().getKey();
+                result.set("key", serialize(key, keySerializer, methodConfig));
+            }
+
+            return result;
         }
 
         private JsonNode mergeKeyIntoValue(JsonNode keyNode, JsonNode valueNode) {

--- a/src/main/java/io/confluent/developer/metrics/RestApiMetrics.java
+++ b/src/main/java/io/confluent/developer/metrics/RestApiMetrics.java
@@ -26,6 +26,11 @@ public class RestApiMetrics implements DynamicMBean {
         try {
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
             ObjectName name = new ObjectName("io.confluent.developer:type=RestApiMetrics");
+            // Registration is idempotent: a prior server instance in this JVM (e.g. after a
+            // Kafka Streams restart) may have left the MBean registered. Replace it.
+            if (mbs.isRegistered(name)) {
+                mbs.unregisterMBean(name);
+            }
             mbs.registerMBean(this, name);
             logger.info("RestApiMetrics MBean registered successfully");
         } catch (Exception e) {

--- a/src/test/java/io/confluent/developer/ConfigurationTest.java
+++ b/src/test/java/io/confluent/developer/ConfigurationTest.java
@@ -712,4 +712,54 @@ public class ConfigurationTest {
 
         assertTrue(exception.getMessage().contains("Only object or array schema types are supported. Found: string for path: /flights"));
     }
+
+    @Test
+    public void testIncludeKeyParsing(@TempDir Path tempDir) throws Exception {
+        Path configPath = tempDir.resolve("include-key-config.yaml");
+        Files.writeString(configPath,
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "\n" +
+            "paths:\n" +
+            "  /items:\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: items\n" +
+            "        query:\n" +
+            "          method: all\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "        includeKey: true\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: items\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n" +
+            "  /other:\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: items\n" +
+            "        query:\n" +
+            "          method: all\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: items\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: array\n"
+        );
+
+        Configuration config = Configuration.fromFile(configPath.toString());
+        assertTrue(config.getPaths().get("/items").getMethods().get("get").getKafka().isIncludeKey());
+        // Defaults to false when omitted
+        assertFalse(config.getPaths().get("/other").getMethods().get("get").getKafka().isIncludeKey());
+    }
 }

--- a/src/test/java/io/confluent/developer/RestApiServerIncludeKeyTest.java
+++ b/src/test/java/io/confluent/developer/RestApiServerIncludeKeyTest.java
@@ -278,6 +278,24 @@ public class RestApiServerIncludeKeyTest {
         assertEquals("message:conv1:0000000002", body.get(1).get("key").asText());
     }
 
+    @Test
+    public void testIncludeKeyDoesNotClobberExistingKeyField(@TempDir Path tempDir) throws Exception {
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        // Value already carries its own "key" field that must be preserved.
+        store.put("k1", "{\"key\":\"payload-key\",\"text\":\"hi\"}");
+
+        startServer(config(tempDir, "all-includekey-clobber.yaml", ALL_INCLUDE_KEY), store);
+
+        HttpResponse<String> response = get("/items");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals(1, body.size());
+        // The payload's own "key" wins; the store key does not overwrite it.
+        assertEquals("payload-key", body.get(0).get("key").asText());
+        assertEquals("hi", body.get(0).get("text").asText());
+    }
+
     static class FakeKeyValueStore implements ReadOnlyKeyValueStore<Object, Object> {
         private final TreeMap<String, String> data = new TreeMap<>();
 

--- a/src/test/java/io/confluent/developer/RestApiServerIncludeKeyTest.java
+++ b/src/test/java/io/confluent/developer/RestApiServerIncludeKeyTest.java
@@ -1,0 +1,247 @@
+package io.confluent.developer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the `includeKey` option, which adds the raw lookup key to each response object under a
+ * "key" field. Because the logic lives in the shared processValue path, it applies consistently to
+ * every query method; this test covers the `all` (array) and `get` (single object) shapes.
+ */
+public class RestApiServerIncludeKeyTest {
+
+    private static final int PORT = 17658;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private RestApiServer server;
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+
+    private Configuration config(Path tempDir, String fileName, String yaml) throws Exception {
+        Path configPath = tempDir.resolve(fileName);
+        Files.writeString(configPath, yaml);
+        return Configuration.fromFile(configPath.toString());
+    }
+
+    private void startServer(Configuration config, ReadOnlyKeyValueStore<Object, Object> store) throws Exception {
+        KafkaStreams streams = Mockito.mock(KafkaStreams.class);
+        Mockito.doReturn(store).when(streams).store(Mockito.any());
+        server = new RestApiServer(streams, config, PORT);
+        server.start();
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:" + PORT + path))
+            .GET()
+            .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private static final String ALL_INCLUDE_KEY =
+        "kafka:\n" +
+        "  application.id: kafka-streams-101\n" +
+        "  bootstrap.servers: localhost:9092\n" +
+        "  schema.registry.url: http://localhost:8081\n" +
+        "paths:\n" +
+        "  /items:\n" +
+        "    get:\n" +
+        "      kafka:\n" +
+        "        topic: items\n" +
+        "        query:\n" +
+        "          method: all\n" +
+        "        serializer:\n" +
+        "          key: string\n" +
+        "          value: string\n" +
+        "        includeKey: true\n" +
+        "      responses:\n" +
+        "        '200':\n" +
+        "          description: items\n" +
+        "          content:\n" +
+        "            application/json:\n" +
+        "              schema:\n" +
+        "                type: array\n";
+
+    @Test
+    public void testIncludeKeyAddsKeyToEachItem(@TempDir Path tempDir) throws Exception {
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        store.put("message:conv1:0000000011", "{\"role\":\"assistant\",\"text\":\"a brand new reply\"}");
+        store.put("message:conv1:0000000001", "{\"role\":\"user\",\"text\":\"hello\"}");
+
+        startServer(config(tempDir, "all-includekey.yaml", ALL_INCLUDE_KEY), store);
+
+        HttpResponse<String> response = get("/items");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals(2, body.size());
+        // TreeMap order: 0000000001 before 0000000011
+        assertEquals("message:conv1:0000000001", body.get(0).get("key").asText());
+        assertEquals("hello", body.get(0).get("text").asText());
+        assertEquals("message:conv1:0000000011", body.get(1).get("key").asText());
+        assertEquals("a brand new reply", body.get(1).get("text").asText());
+    }
+
+    @Test
+    public void testWithoutIncludeKeyThereIsNoKeyField(@TempDir Path tempDir) throws Exception {
+        String yamlNoKey = ALL_INCLUDE_KEY.replace("        includeKey: true\n", "");
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        store.put("message:conv1:0000000001", "{\"role\":\"user\",\"text\":\"hello\"}");
+
+        startServer(config(tempDir, "all-nokey.yaml", yamlNoKey), store);
+
+        HttpResponse<String> response = get("/items");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertEquals(1, body.size());
+        assertFalse(body.get(0).has("key"), "key field should be absent when includeKey is not set");
+    }
+
+    @Test
+    public void testIncludeKeyOnGetSingleObject(@TempDir Path tempDir) throws Exception {
+        String getYaml =
+            "kafka:\n" +
+            "  application.id: kafka-streams-101\n" +
+            "  bootstrap.servers: localhost:9092\n" +
+            "  schema.registry.url: http://localhost:8081\n" +
+            "paths:\n" +
+            "  /items/{id}:\n" +
+            "    parameters:\n" +
+            "    - name: id\n" +
+            "      in: path\n" +
+            "      description: the item id\n" +
+            "    get:\n" +
+            "      kafka:\n" +
+            "        topic: items\n" +
+            "        query:\n" +
+            "          method: get\n" +
+            "          key: ${parameters.id}\n" +
+            "        serializer:\n" +
+            "          key: string\n" +
+            "          value: string\n" +
+            "        includeKey: true\n" +
+            "      responses:\n" +
+            "        '200':\n" +
+            "          description: one item\n" +
+            "          content:\n" +
+            "            application/json:\n" +
+            "              schema:\n" +
+            "                type: object\n";
+
+        FakeKeyValueStore store = new FakeKeyValueStore();
+        store.put("abc", "{\"text\":\"hi\"}");
+
+        startServer(config(tempDir, "get-includekey.yaml", getYaml), store);
+
+        HttpResponse<String> response = get("/items/abc");
+        assertEquals(200, response.statusCode());
+
+        JsonNode body = MAPPER.readTree(response.body());
+        assertTrue(body.isObject());
+        assertEquals("abc", body.get("key").asText());
+        assertEquals("hi", body.get("text").asText());
+    }
+
+    static class FakeKeyValueStore implements ReadOnlyKeyValueStore<Object, Object> {
+        private final TreeMap<String, String> data = new TreeMap<>();
+
+        void put(String key, String value) {
+            data.put(key, value);
+        }
+
+        @Override
+        public Object get(Object key) {
+            return data.get(key);
+        }
+
+        @Override
+        public KeyValueIterator<Object, Object> range(Object from, Object to) {
+            List<KeyValue<Object, Object>> entries = new ArrayList<>();
+            for (var e : data.subMap((String) from, true, (String) to, true).entrySet()) {
+                entries.add(new KeyValue<>(e.getKey(), e.getValue()));
+            }
+            return new ListIterator(entries);
+        }
+
+        @Override
+        public KeyValueIterator<Object, Object> all() {
+            List<KeyValue<Object, Object>> entries = new ArrayList<>();
+            for (var e : data.entrySet()) {
+                entries.add(new KeyValue<>(e.getKey(), e.getValue()));
+            }
+            return new ListIterator(entries);
+        }
+
+        @Override
+        public long approximateNumEntries() {
+            return data.size();
+        }
+    }
+
+    static class ListIterator implements KeyValueIterator<Object, Object> {
+        private final Iterator<KeyValue<Object, Object>> it;
+        private final List<KeyValue<Object, Object>> entries;
+        private int index = 0;
+
+        ListIterator(List<KeyValue<Object, Object>> entries) {
+            this.entries = entries;
+            this.it = entries.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return it.hasNext();
+        }
+
+        @Override
+        public KeyValue<Object, Object> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            index++;
+            return it.next();
+        }
+
+        @Override
+        public Object peekNextKey() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return entries.get(index).key;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a boolean **`kafka.includeKey`** option (default `false`) that adds the raw lookup key to each returned object under a `key` field. It lives in the shared `processValue` path, so it applies consistently to **every query method** (`all`, `get`, and the range/prefix scans in #60/#61).

```yaml
kafka:
  topic: conversation-store
  query: { method: all }
  serializer: { key: string, value: string }
  includeKey: true
```

The entry:
```
key:   message:conv1:0000000011
value: {"role":"assistant","text":"a brand new reply"}
```
is returned as:
```json
{ "role": "assistant", "text": "a brand new reply", "key": "message:conv1:0000000011" }
```

## Behavior

- String keys are emitted as-is; structured (Avro) keys are serialized to their JSON form.
- If the value is not a JSON object (array/scalar), the key can't be attached and the value is returned unchanged (logged).
- **Distinct from `mergeKey`:** `mergeKey` merges the fields of an Avro *key object* into the value and does not work for plain string keys; `includeKey` adds the raw key itself under `key`, following the same boolean-option pattern as `mergeKey`/`includeType`.

## Other

- **RestApiMetrics** — make JMX MBean registration idempotent (a second `RestApiServer` in one JVM previously threw `InstanceAlreadyExistsException`).

## Testing

`./gradlew clean test` → **28 tests, 28 succeeded**.

- `ConfigurationTest`: `includeKey` parses to true, defaults to false when omitted.
- `RestApiServerIncludeKeyTest`: HTTP-level — `all` adds `key` to each array item (ordered), `get` adds `key` to the single object, and the field is absent when `includeKey` is not set.

Independent of #60 (`range`) and #61 (`prefix`); composes with both since the logic is in the shared serialization path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)